### PR TITLE
Reset data layer state within tests instead of production code

### DIFF
--- a/backend/chainlit/server.py
+++ b/backend/chainlit/server.py
@@ -1529,25 +1529,25 @@ async def get_storage_file(
 ):
     """Get a file from the storage client if it supports direct downloads."""
     from chainlit.data import get_data_layer
-    
+
     data_layer = get_data_layer()
     if not data_layer or not data_layer.storage_client:
         raise HTTPException(
             status_code=404,
             detail="Storage not configured",
         )
-    
+
     # Validate user authentication
     if not current_user:
         raise HTTPException(status_code=401, detail="Unauthorized")
-    
+
     # Extract thread_id from object_key to validate thread ownership
     # Object key patterns:
     # 1. threads/{thread_id}/files/{element.id} (chainlit_data_layer)
-    # 2. {user_id}/{thread_id}/{element.id} (dynamodb) 
+    # 2. {user_id}/{thread_id}/{element.id} (dynamodb)
     # 3. {user_id}/{element.id}[/{element.name}] (sql_alchemy)
     thread_id = None
-    
+
     # Try to extract thread_id from different patterns
     parts = object_key.split("/")
     if len(parts) >= 3:
@@ -1565,7 +1565,7 @@ async def get_storage_file(
             except HTTPException:
                 # Not a valid thread or user doesn't have access
                 pass
-    
+
     # If we found a thread_id, validate thread ownership
     if thread_id:
         await is_thread_author(current_user.identifier, thread_id)
@@ -1576,10 +1576,10 @@ async def get_storage_file(
             user_id_in_path = parts[0]
             if user_id_in_path != current_user.identifier:
                 raise HTTPException(
-                    status_code=403, 
-                    detail="Access denied: file belongs to different user"
+                    status_code=403,
+                    detail="Access denied: file belongs to different user",
                 )
-    
+
     # Try to extract element_id and get the original filename from database
     element_id = None
     element_name = None
@@ -1608,10 +1608,11 @@ async def get_storage_file(
     filename = element_name if element_name else Path(object_key).name
 
     from fastapi.responses import Response
+
     return Response(
         content=content,
         media_type=mime_type,
-        headers={"Content-Disposition": f"inline; filename={filename}"}
+        headers={"Content-Disposition": f"inline; filename={filename}"},
     )
 
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -95,11 +95,24 @@ def mock_data_layer(monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
 
 @pytest.fixture
 def mock_get_data_layer(mock_data_layer: AsyncMock, test_config: config.ChainlitConfig):
+    from chainlit import data as data_module
+
     # Instantiate mock data layer
     mock_get_data_layer = Mock(return_value=mock_data_layer)
 
-    # Configure it using @data_layer decorator
-    return data_layer(mock_get_data_layer)
+    original_data_layer = data_module._data_layer
+    original_initialized = data_module._data_layer_initialized
+
+    data_module._data_layer = None
+    data_module._data_layer_initialized = False
+
+    data_layer(mock_get_data_layer)
+
+    try:
+        yield mock_get_data_layer
+    finally:
+        data_module._data_layer = original_data_layer
+        data_module._data_layer_initialized = original_initialized
 
 
 @pytest.fixture

--- a/backend/tests/data/storage_clients/test_local.py
+++ b/backend/tests/data/storage_clients/test_local.py
@@ -255,6 +255,7 @@ class TestLocalStorageAPIIntegration:
 
         data_layer = Mock()
         data_layer.storage_client = client
+        data_layer.get_element = AsyncMock(return_value=None)
 
         with patch("chainlit.data.get_data_layer", return_value=data_layer):
             yield data_layer
@@ -413,9 +414,7 @@ class TestLocalStorageAPIIntegration:
                 return True
             raise HTTPException(status_code=403, detail="Access denied")
 
-        with patch(
-            "chainlit.server.is_thread_author", side_effect=mock_is_thread_author
-        ):
+        with patch("chainlit.server.is_thread_author", new=mock_is_thread_author):
             # Authorized user should succeed
             def mock_get_authorized_user():
                 return authorized_user


### PR DESCRIPTION
## Summary
- remove the production-only `reset_data_layer` helper so the data layer decorator no longer mutates global state
- update the shared `mock_get_data_layer` fixture to save and restore the cached data layer around each test

## Testing
- uv run pytest backend/tests/data/test_get_data_layer.py backend/tests/test_callbacks.py

------
https://chatgpt.com/codex/tasks/task_e_68d0daa2572883238b48876041dc369f