### PR TITLE
Fix backend tests conftest imports

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -9,7 +9,6 @@ import pytest_asyncio
 
 import chainlit.data as data_module
 from chainlit import config
-import chainlit.data as data_module
 from chainlit.callbacks import data_layer
 from chainlit.context import ChainlitContext, context_var
 from chainlit.data.base import BaseDataLayer


### PR DESCRIPTION
## Summary
- remove the duplicate `chainlit.data` import in `backend/tests/conftest.py` to resolve ruff lint errors

## Testing
- ruff check backend/tests/conftest.py

------
https://chatgpt.com/codex/tasks/task_e_68d176c37e3c8323aa48e9389b4b78ab